### PR TITLE
WIP: extend jplyr interface

### DIFF
--- a/src/SQLQuery.jl
+++ b/src/SQLQuery.jl
@@ -1,106 +1,26 @@
 module SQLQuery
 
-    export @sqlquery, translatesql
+using Reexport
+@reexport using jplyr
+@reexport using Tables
+@reexport using SQLite
+@reexport using DataStreams
 
-     abstract QueryNode{T}
-     abstract JoinNode{T} <: QueryNode{T}
-    typealias QueryArg Union{Symbol, Expr}
-    typealias QueryArgs Vector{QueryArg}
-    typealias QuerySource Union{Symbol, QueryNode}
+export  SQLTable,
+        SQLiteTable,
+        translatesql
 
-    type SelectNode{T} <: QueryNode{T}
-        input::T
-        args::QueryArgs
-    end
+# Extend jplyr.QueryNode framework
+include("querynode/typedefs.jl")
 
-    type DistinctNode{T} <: QueryNode{T}
-        input::T
-        args::QueryArgs
-    end
+# SQLTable
+include("sqltable/typedef.jl")
 
-    type FilterNode{T} <: QueryNode{T}
-        input::T
-        args::Vector{Expr}
-    end
+# SQLiteTable
+include("sqlitetable/typedef.jl")
 
-    type GroupbyNode{T} <: QueryNode{T}
-        input::T
-        args::QueryArgs
-    end
+# Query interface
+include("sqltable/query/collect.jl")
+include("sqltable/query/translate.jl")
 
-    type OrderbyNode{T} <: QueryNode{T}
-        input::T
-        args::QueryArgs
-    end
-
-    type LimitNode{T} <: QueryNode{T}
-        input::T
-        limit::Vector{Int}
-    end
-
-    type OffsetNode{T} <: QueryNode{T}
-        input::T
-        offset::Vector{Int}
-    end
-
-    type LeftJoinNode{T} <: JoinNode{T}
-        input::T
-        args::QueryArgs
-    end
-
-    type OuterJoinNode{T} <: JoinNode{T}
-        input::T
-        args::QueryArgs
-    end
-
-    type InnerJoinNode{T} <: JoinNode{T}
-        input::T
-        args::QueryArgs
-    end
-
-    type CrossJoinNode{T} <: JoinNode{T}
-        input::T
-        args::QueryArgs
-    end
-
-    Base.show(io::IO, q::QueryNode) = print(io, translatesql(q))
-
-    QUERYNODE = Dict(:select => SelectNode,
-                     :distinct => DistinctNode,
-                     :filter => FilterNode,
-                     :groupby => GroupbyNode,
-                     :orderby => OrderbyNode,
-                     :limit => LimitNode,
-                     :offset => OffsetNode,
-                     :leftjoin => LeftJoinNode,
-                     :outerjoin => OuterJoinNode,
-                     :innerjoin => InnerJoinNode,
-                     :crossjoin => CrossJoinNode)
-
-        exf(ex::Expr) = ex.args[1]
-    exfargs(ex::Expr) = ex.args[2:end]
-
-    macro sqlquery(args...)
-        @assert isa(args, Tuple{Expr}) "Invalid Query Expression"
-        _sqlquery(args)
-    end
-
-    _sqlquery(expr::Symbol) = expr
-    _sqlquery(expr::Tuple{Expr}) = _sqlquery(expr[1])
-
-    function _sqlquery(ex::Expr)
-        @assert ex.head == :call
-        pipe = exf(ex); args = exfargs(ex)
-        @assert pipe == :|>
-        @assert length(args) == 2
-        subquery, verb = args
-        source = _sqlquery(subquery)
-        @assert isa(source, QuerySource)
-        @assert isa(verb, Expr)
-        @assert verb.head == :call
-        querytype = exf(verb); queryargs = exfargs(verb)
-        QUERYNODE[querytype]{typeof(source)}(source, queryargs)
-    end
-
-    include("translate.jl")
 end

--- a/src/querynode/typedefs.jl
+++ b/src/querynode/typedefs.jl
@@ -1,0 +1,18 @@
+# using jplyr: QueryNode, JoinNode,
+typealias QueryArgs Vector{jplyr.QueryArg}
+typealias QuerySource Union{Symbol, jplyr.QueryNode}
+
+type DistinctNode <: jplyr.QueryNode
+    input::jplyr.QueryNode
+    args::QueryArgs
+end
+
+type LimitNode <: jplyr.QueryNode
+    input::jplyr.QueryNode
+    limit::Vector{Int}
+end
+
+type OffsetNode <: jplyr.QueryNode
+    input::jplyr.QueryNode
+    offset::Vector{Int}
+end

--- a/src/sqlitetable/typedef.jl
+++ b/src/sqlitetable/typedef.jl
@@ -1,0 +1,12 @@
+"""
+"""
+type SQLiteTable <: SQLTable
+    db::SQLite.DB
+    tbl_name
+end
+
+(::Type{SQLiteTable})(db::AbstractString, tbl_name::AbstractString) =
+    SQLiteTable(SQLite.DB(db), tbl_name)
+
+(::Type{SQLiteTable})(tbl_name::AbstractString) =
+    SQLiteTable(SQLite.DB(), tbl_name)

--- a/src/sqltable/query/collect.jl
+++ b/src/sqltable/query/collect.jl
@@ -1,0 +1,10 @@
+AbstractTables.default(::SQLTable) = Table()
+
+function Base.collect(tbl::SQLTable, graph::jplyr.QueryNode)
+    jplyr.set_src!(graph, tbl)
+    sql = translatesql(graph)
+    source = SQLite.Source(tbl.db, sql)
+    res = Table(Data.schema(source))
+    Data.stream!(source, Data.Field, res, false)
+    return res
+end

--- a/src/sqltable/typedef.jl
+++ b/src/sqltable/typedef.jl
@@ -1,0 +1,1 @@
+abstract SQLTable


### PR DESCRIPTION
This PR reframes the SQL translation regime implemented in SQLQuery as an extension of the jplyr querying framework. The translation logic is left essentially untouched.

This PR introduces the following broad changes:
1. It introduces the abstract `SQLTable <: AbstractTable` and the concrete `SQLiteTable <: SQLTable`. The latter is a thin wrapper around a `SQLite.DB` connection and a field that names the table.
2. The present package is made to rely on `jplyr` to provide the graph generation `@query` macro. The intended user-facing interface is that users use `@query src |> ...`, where `src` is an object of type `T <: SQLTable` to generate a `Query{T}`, which they can then `collect` against `src`. (Note that `jplyr` does not support all of the `QueryNode` leaf subtype objects that the present package does, in particular `DistinctNode`, `LimitNode`, and `OffsetNode`. Thus, the present package introduces these types and illustrates (or will illustrate) jplyr's `QueryNode` registration mechanism (which still needs some work).)
3. The SQL translation machinery is thinly wrapped by `Base.collect(tbl::SQLTable, graph::jplyr.QueryNode)`, which translates the `graph` into a SQL string via `translatesql` and runs the query against `tbl`. By default, the results set is streamed into a `Tables.Table`. 
4. A bunch of file reorganization. The philosophy is to segregate functionality by the primary type they concern (e.g. `QueryNode` objects, `SQLTable`s or `SQLiteTable`s). In the `sqltable` and `sqlitetable` folders, a `query` folder houses the code relevant to extending the jplyr `collect` machinery. `translate.jl` lives in `sqltable/query`. 

TO-DO (not exhaustive):
- [ ] finalize and implement `jplyr.QueryNode` registration framework
- [ ] implement primitives for `QueryNode` leaf subtypes, for `SQLTable`s/`SQLiteTable`s
- [ ] polish `DataStreams` interfacing
- [ ] documentation!
- [ ] tests
- [ ] figure out story of registering/requiring `AbstractTables`/`Tables`/`jplyr`

Here's a teaser (relying on new work in `Tables`/`AbtractTables`/`jplyr` that I haven't yet pushed):

``` julia
julia> using SQLQuery

julia> iris_sql = SQLiteTable("/Users/David/.julia/v0.5/SQLQuery/db/iris.db", "iris")
SQLQuery.SQLiteTable(SQLite.DB("/Users/David/.julia/v0.5/SQLQuery/db/iris.db"),"iris")

julia> iris_tbl = Table(CSV.Source("/Users/David/.julia/v0.5/SQLQuery/csv/iris.csv"))
Tables.Table
│ Row │ sepal_length │ sepal_width │ petal_length │ petal_width │ species  │
├─────┼──────────────┼─────────────┼──────────────┼─────────────┼──────────┤
│ 1   │ 5.1          │ 3.5         │ 1.4          │ 0.2         │ "setosa" │
│ 2   │ 4.9          │ 3.0         │ 1.4          │ 0.2         │ "setosa" │
│ 3   │ 4.7          │ 3.2         │ 1.3          │ 0.2         │ "setosa" │
│ 4   │ 4.6          │ 3.1         │ 1.5          │ 0.2         │ "setosa" │
│ 5   │ 5.0          │ 3.6         │ 1.4          │ 0.2         │ "setosa" │
│ 6   │ 5.4          │ 3.9         │ 1.7          │ 0.4         │ "setosa" │
│ 7   │ 4.6          │ 3.4         │ 1.4          │ 0.3         │ "setosa" │
│ 8   │ 5.0          │ 3.4         │ 1.5          │ 0.2         │ "setosa" │
│ 9   │ 4.4          │ 2.9         │ 1.4          │ 0.2         │ "setosa" │
│ 10  │ 4.9          │ 3.1         │ 1.5          │ 0.1         │ "setosa" │
⋮
with 140 more rows.

julia> qry = @query :src |>
           filter(sepal_length > 5.0) |>
           select(species, sepal_length, petal_width)
Query with dummy source src

julia> collect(qry, src=iris_tbl)
Tables.Table
│ Row │ species  │ sepal_length │ petal_width │
├─────┼──────────┼──────────────┼─────────────┤
│ 1   │ "setosa" │ 5.1          │ 0.2         │
│ 2   │ "setosa" │ 5.4          │ 0.4         │
│ 3   │ "setosa" │ 5.4          │ 0.2         │
│ 4   │ "setosa" │ 5.8          │ 0.2         │
│ 5   │ "setosa" │ 5.7          │ 0.4         │
│ 6   │ "setosa" │ 5.4          │ 0.4         │
│ 7   │ "setosa" │ 5.1          │ 0.3         │
│ 8   │ "setosa" │ 5.7          │ 0.3         │
│ 9   │ "setosa" │ 5.1          │ 0.3         │
│ 10  │ "setosa" │ 5.4          │ 0.2         │
⋮
with 108 more rows.

julia> collect(qry, src=iris_sql)
Tables.Table
│ Row │ species  │ sepal_length │ petal_width │
├─────┼──────────┼──────────────┼─────────────┤
│ 1   │ "setosa" │ "5.1"        │ "0.2"       │
│ 2   │ "setosa" │ "5.4"        │ "0.4"       │
│ 3   │ "setosa" │ "5.4"        │ "0.2"       │
│ 4   │ "setosa" │ "5.8"        │ "0.2"       │
│ 5   │ "setosa" │ "5.7"        │ "0.4"       │
│ 6   │ "setosa" │ "5.4"        │ "0.4"       │
│ 7   │ "setosa" │ "5.1"        │ "0.3"       │
│ 8   │ "setosa" │ "5.7"        │ "0.3"       │
│ 9   │ "setosa" │ "5.1"        │ "0.3"       │
│ 10  │ "setosa" │ "5.4"        │ "0.2"       │
⋮
with 108 more rows.
```
